### PR TITLE
build: Add flag to disable update checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,10 @@ else ifneq (,$(findstring mingw,$(CCMACHINE)))
 TARGET_ARCH2 = x86
 endif
 
+ifneq ($(DISABLE_UPDATER),)
+EXTRA_CXXFLAGS += -DST_NO_UPDATES_CHECK
+endif
+
 # to activate debug build
 #EXTRA_CXXFLAGS = -DST_DEBUG_LOG_TO_FILE=\"/sdcard/Android/data/com.sview/files/sview.log\" -DST_DEBUG
 #EXTRA_CXXFLAGS += -DST_DEBUG_GL


### PR DESCRIPTION
The update checking preferences are still present in the UI though.

This isn't a great patch, but shows what I'd like to achieve. A Flatpak of sView can't update itself, and needs to rely on the app being updated by the OS, so there's no need to check for updates. The patch here does the minimum amount of work to stop sView from prodding a website (over HTTP as well!), but doesn't remove the update preferences.